### PR TITLE
chore: workflows del pipeline (F4) — upload cayo en rama 'Develop' por mayuscula

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+# CI de what-money-cant-buy — ADR-003. Human-execute como todo yml.
+# Cinco checks, todos ley de spec; en verde materializa `ci-verde` en el PR.
+name: CI
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: JSONs de raiz validos (spec §3)
+        run: |
+          set -e
+          for f in *.json; do
+            python3 -c "import json,sys; json.load(open('$f'))" || { echo "JSON invalido: $f"; exit 1; }
+            echo "OK $f"
+          done
+
+      - name: Sintaxis Python (py_compile)
+        run: |
+          set -e
+          for f in update.py setup_season.py build_crests.py test_season_transition.py; do
+            python3 -m py_compile "$f" && echo "OK $f"
+          done
+
+      - name: Completitud i18n — par [en, es] no vacio (spec §2.5 / §3bis.6)
+        run: |
+          python3 - << 'EOF'
+          import json, sys
+          d = json.load(open('i18n.json'))
+          bad = [k for k, v in d.items()
+                 if not (isinstance(v, list) and len(v) == 2
+                         and all(isinstance(x, str) and x.strip() for x in v))]
+          if bad:
+              print("Claves i18n incompletas:", bad[:20]); sys.exit(1)
+          print(f"OK {len(d)} claves con par [en, es] completo")
+          EOF
+
+      - name: Sintaxis JS de index.html (node --check, spec §3bis.7)
+        run: |
+          python3 - << 'EOF'
+          import re, subprocess, sys
+          html = open('index.html').read()
+          scripts = re.findall(r'<script(?![^>]*\bsrc=)[^>]*>(.*?)</script>', html, re.S)
+          inline = [s for s in scripts if s.strip()]
+          if not inline:
+              print("Sin <script> inline que chequear"); sys.exit(0)
+          for i, s in enumerate(inline):
+              open(f'/tmp/inline_{i}.js', 'w').write(s)
+              r = subprocess.run(['node', '--check', f'/tmp/inline_{i}.js'],
+                                 capture_output=True, text=True)
+              if r.returncode != 0:
+                  print(f"Sintaxis JS invalida en script inline #{i}:\n{r.stderr}")
+                  sys.exit(1)
+          print(f"OK {len(inline)} scripts inline")
+          EOF
+
+      - name: Guardia de SW — bump obligatorio si cambia index.html (spec §3bis.1, solo PRs)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -e
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+          if echo "$CHANGED" | grep -qx 'index.html'; then
+            if git diff "$BASE" "$HEAD" -- sw.js | grep -q 'CACHE_NAME'; then
+              echo "OK: index.html cambia y CACHE_NAME tambien"
+            else
+              echo "BLOQUEADO: el PR toca index.html sin bump de CACHE_NAME en sw.js (spec §3bis.1)"
+              exit 1
+            fi
+          else
+            echo "index.html sin cambios; guardia no aplica"
+          fi
+
+      - name: Materializar ci-verde (solo PRs)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --add-label ci-verde
+          echo "ci-verde materializado en PR #$PR"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,28 @@
+# STUB (agent-pipeline): triggers aquí; lógica en el central. Anclar @vN.
+name: Claude Code
+on:
+  issues:
+    types: [opened, edited, assigned]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+jobs:
+  call:
+    uses: talfarouriarte-cloud/agent-pipeline/.github/workflows/claude-code.yml@v1
+    with:
+      runner: ubuntu-latest
+      default_branch: develop
+      creator_model: claude-opus-4-8
+      creator_max_turns: 100
+      bot_comment_cap: 8
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      REVIEWER_GITHUB_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}

--- a/.github/workflows/epic-merge.yml
+++ b/.github/workflows/epic-merge.yml
@@ -1,0 +1,30 @@
+# STUB (agent-pipeline). workflow_run debe listar los name: EXACTOS de los
+# stubs de CI y Reviewer de ESTE repo; ci_workflow_name debe coincidir.
+name: Epic Merge
+on:
+  workflow_run:
+    workflows: ["CI", "Opus Reviewer"]
+    types: [completed]
+  pull_request:
+    types: [closed, labeled]
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
+  actions: read
+concurrency:
+  group: epic-merge-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+jobs:
+  call:
+    uses: talfarouriarte-cloud/agent-pipeline/.github/workflows/epic-merge.yml@v1
+    with:
+      runner: ubuntu-latest
+      default_branch: develop
+      ci_workflow_name: CI
+      epic_label: epica
+      partial_round_cap: 3
+      partial_lifetime_cap: 6
+    secrets:
+      REVIEWER_GITHUB_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}

--- a/.github/workflows/process-review.yml
+++ b/.github/workflows/process-review.yml
@@ -1,0 +1,24 @@
+# STUB (agent-pipeline).
+name: Process Reviewer
+on:
+  issues:
+    types: [labeled]
+permissions:
+  contents: read
+  issues: write
+concurrency:
+  group: process-reviewer
+  cancel-in-progress: false
+jobs:
+  call:
+    uses: talfarouriarte-cloud/agent-pipeline/.github/workflows/process-review.yml@v1
+    with:
+      runner: ubuntu-latest
+      default_branch: develop
+      process_model: claude-fable-5
+      process_fallback_model: claude-opus-4-8
+      process_max_turns: 60
+      timeout_minutes: 20
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      REVIEWER_GITHUB_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -1,0 +1,26 @@
+# STUB (agent-pipeline). concurrency AQUÍ y con cancel-in-progress: false
+# (obligatorio: un labeled espurio no puede matar una review en vuelo).
+name: Opus Reviewer
+on:
+  pull_request:
+    types: [opened, labeled]
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+concurrency:
+  group: reviewer-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+jobs:
+  call:
+    uses: talfarouriarte-cloud/agent-pipeline/.github/workflows/reviewer.yml@v1
+    with:
+      runner: ubuntu-latest
+      reviewer_model: claude-opus-4-8
+      reviewer_max_turns: 50
+      timeout_minutes: 15
+      agent_branch_prefix: claude/
+      review_context: ""
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      REVIEWER_GITHUB_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}

--- a/.github/workflows/watchdog-heartbeat.yml
+++ b/.github/workflows/watchdog-heartbeat.yml
@@ -1,0 +1,149 @@
+# TEMPLATE (agent-pipeline): copiar al repo consumidor y sustituir
+# develop por la rama por defecto. NO es workflow_call a propósito:
+# el vigilante del vigilante debe correr en infraestructura independiente de
+# lo que vigila (runner GitHub-hosted, cero LLM) y sin dependencia del central.
+name: Watchdog Heartbeat
+
+# Latido del vigilante (2026-07-07): el régimen autónomo depende de que
+# watchdog.yml corra, pero nadie vigilaba al vigilante. Su cron es
+# best-effort (observado: 2 runs en 5h pese al */20) y workflow_run solo
+# dispara si ALGO corre — silencio total del pipeline es su punto ciego.
+#
+# Este workflow, con cron propio e independiente, hace dos cosas baratas
+# y deterministas (cero LLM):
+#
+#   1. REVIVIR: si el último run del Watchdog envejece > STALE_MIN,
+#      re-dispararlo vía workflow_dispatch (autoreparación, cero humano)
+#      y verificar en la misma corrida que el run nace. Solo si el
+#      dispatch falla o el run no aparece (vigilante muerto e
+#      irreanimable — p. ej. workflow deshabilitado) abre issue
+#      `human-needed`. Única vía nueva a humano, y genuinamente
+#      terminal: un watchdog irreanimable suele implicar tocar
+#      workflows, que es gate humano de todas formas.
+#
+#   2. DIGEST: sincroniza los comentarios <!-- autonomous-decision --> y
+#      <!-- derived-decision --> recientes al issue-registro (label
+#      `registro-decisiones`, creado idempotentemente, pinnearlo es
+#      cosmético). Convierte el veto asíncrono en ejercible: un solo
+#      lugar que mirar, en vez de comentarios dispersos por issues.
+#
+# GITHUB_TOKEN basta para todo: workflow_dispatch y repository_dispatch
+# son las dos excepciones documentadas del anti-loop de GitHub (eventos
+# del GITHUB_TOKEN no disparan otros workflows, SALVO estos dos). El
+# issue-digest no necesita disparar nada.
+
+on:
+  schedule:
+    # Cada 30 min, minutos desplazados: los crons en :00/:20/:30 sufren
+    # más throttling por congestión de la cola compartida de GitHub.
+    - cron: '13,43 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  actions: write     # listar runs del watchdog + dispatch de revival
+  issues: write      # issue de escalada + digest
+
+concurrency:
+  group: watchdog-heartbeat
+  cancel-in-progress: true
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Revivir watchdog si está muerto
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const WF = 'watchdog.yml';
+            const STALE_MIN = 90;   // watchdog: cron */20 + workflow_run → 90 min de silencio = muerto
+            const now = Date.now();
+
+            async function latestRunAgeMin() {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: WF, per_page: 1 });
+              if (!data.workflow_runs.length) return Infinity;
+              return (now - new Date(data.workflow_runs[0].created_at).getTime()) / 60000;
+            }
+
+            async function escalate(reason) {
+              // Dedupe: no abrir un segundo issue si ya hay uno abierto.
+              const q = `repo:${owner}/${repo} is:issue is:open in:title "Watchdog muerto"`;
+              const { data: found } = await github.rest.search.issuesAndPullRequests({ q });
+              if (found.total_count > 0) { core.info('escalada ya abierta, no duplico'); return; }
+              await github.rest.issues.create({ owner, repo,
+                title: 'Watchdog muerto e irreanimable — intervención humana',
+                labels: ['human-needed'],
+                body: `El heartbeat detectó el Watchdog parado (último run hace >${STALE_MIN} min) y el revival automático falló: ${reason}\n\nComprobar: Actions → Watchdog (¿workflow deshabilitado?), quota, y los runs recientes de este heartbeat.\n\n<!-- watchdog-heartbeat-escalation -->` });
+              core.warning('Watchdog irreanimable: issue human-needed creado.');
+            }
+
+            const age = await latestRunAgeMin();
+            core.info(`Último run del watchdog: hace ${Math.round(age)} min`);
+            if (age <= STALE_MIN) return;
+
+            core.warning(`Watchdog parado (${Math.round(age)} min). Intento revival via workflow_dispatch.`);
+            try {
+              await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: WF, ref: 'develop' });
+            } catch (e) { await escalate(`el dispatch lanzó error: ${e.message}`); return; }
+
+            // Verificar que el run nace (hasta ~2 min). Si no, escalar.
+            let revived = false;
+            for (let i = 0; i < 8; i++) {
+              await new Promise(r => setTimeout(r, 15000));
+              if (await latestRunAgeMin() < STALE_MIN) { revived = true; break; }
+            }
+            if (revived) core.notice('Watchdog revivido por dispatch.');
+            else await escalate('el dispatch no produjo ningún run en 2 min.');
+
+      - name: Digest de decisiones autónomas
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const MARKERS = ['<!-- autonomous-decision -->', '<!-- derived-decision -->'];
+            const WINDOW_H = 26;   // ventana generosa; el dedupe por URL evita duplicados
+
+            // 1. Localizar (o crear, idempotente) el issue-registro.
+            let digest = null;
+            const { data: regs } = await github.rest.issues.listForRepo({
+              owner, repo, labels: 'registro-decisiones', state: 'open', per_page: 1 });
+            if (regs.length) digest = regs[0];
+            else {
+              const { data: created } = await github.rest.issues.create({ owner, repo,
+                title: 'Registro de decisiones autónomas (digest)',
+                labels: ['registro-decisiones'],
+                body: 'Digest mecánico de comentarios `<!-- autonomous-decision -->` y `<!-- derived-decision -->` de todo el repo, sincronizado por watchdog-heartbeat.yml. Veto asíncrono: revisar aquí, revertir en origen. No cerrar: el heartbeat lo recrearía.' });
+              digest = created;
+              core.notice(`Issue-registro creado: #${digest.number}`);
+            }
+
+            // 2. Comentarios recientes de TODO el repo (issues y PRs) con marcador.
+            const since = new Date(Date.now() - WINDOW_H * 3600000).toISOString();
+            const recent = await github.paginate(github.rest.issues.listCommentsForRepo,
+              { owner, repo, since, per_page: 100 });
+            const decisions = recent.filter(c =>
+              MARKERS.some(m => (c.body || '').includes(m)) &&
+              !(c.html_url || '').includes(`/issues/${digest.number}#`));
+            if (!decisions.length) { core.info('Sin decisiones nuevas en la ventana.'); return; }
+
+            // 3. Dedupe por URL contra lo ya registrado en el digest.
+            const logged = await github.paginate(github.rest.issues.listComments,
+              { owner, repo, issue_number: digest.number, per_page: 100 });
+            const loggedText = logged.map(c => c.body || '').join('\n');
+            const fresh = decisions.filter(c => !loggedText.includes(c.html_url));
+            if (!fresh.length) { core.info('Todas las decisiones recientes ya registradas.'); return; }
+
+            // 4. Un comentario-digest por corrida con las entradas nuevas.
+            const lines = fresh.map(c => {
+              const kind = (c.body || '').includes(MARKERS[0]) ? 'AUTONOMOUS' : 'DERIVED';
+              const excerpt = (c.body || '').replace(/<!--[^>]*-->/g, '').trim()
+                .replace(/\s+/g, ' ').slice(0, 300);
+              return `- **[${kind}]** ${c.html_url}\n  > ${excerpt}…`;
+            });
+            await github.rest.issues.createComment({ owner, repo, issue_number: digest.number,
+              body: `Sincronización ${new Date().toISOString().slice(0, 16)}Z — ${fresh.length} decisión(es) nueva(s):\n\n${lines.join('\n')}` });
+            core.notice(`${fresh.length} decisiones añadidas al digest #${digest.number}.`);

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,0 +1,41 @@
+# STUB (agent-pipeline). Los nombres de workflows del pipeline de ESTE repo
+# van en workflow_run Y en los inputs *_workflow_name (el detector compara).
+name: Watchdog
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+  schedule:
+    - cron: '*/20 * * * *'
+  workflow_run:
+    workflows: ["Claude Code", "Opus Reviewer", "Epic Merge"]
+    types: [completed]
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: write
+  id-token: write
+concurrency:
+  group: watchdog
+  cancel-in-progress: false
+jobs:
+  call:
+    uses: talfarouriarte-cloud/agent-pipeline/.github/workflows/watchdog.yml@v1
+    with:
+      runner: ubuntu-latest
+      default_branch: develop
+      ci_workflow_name: CI
+      creator_workflow_name: Claude Code
+      reviewer_workflow_name: Opus Reviewer
+      epic_merge_workflow_name: Epic Merge
+      extra_pipeline_workflows: ""
+      epic_label: epica
+      resolve_model: claude-opus-4-8
+      resolve_max_turns: 40
+      lookback_min: 45
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      REVIEWER_GITHUB_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}


### PR DESCRIPTION
Los 7 yml de F4 se subieron a una rama nueva `Develop` (D mayuscula) en vez de `develop`. Este PR los trae a la rama de trabajo. **Merge manual del propietario** (los yml exigen escritura humana). Tras el merge, borrar la rama `Develop` para eliminar la ambiguedad de nombre.