### PR TITLE
feat: ranking oficial por liga en data.json (ADR-005)

### DIFF
--- a/test_tiebreakers.py
+++ b/test_tiebreakers.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+Tests de los criterios de desempate de la clasificación real (ADR-005).
+
+Ejecutable standalone con exit code (asserts, sin prints de resultado):
+    python3 test_tiebreakers.py
+
+Cubre (9 tests):
+  - 6 unitarios, uno por liga, con fixtures sintéticos que ejercitan la
+    cadena de TIEBREAKERS de esa liga (La Liga con triple empate resuelto
+    por mini-liga).
+  - 1 de contorno (a): enfrentamientos incompletos -> criterios generales.
+  - 1 de integridad: rank es permutación exacta 1..N en toda liga x temporada
+    del fixture.
+  - 1 de no-regresión: attach_ranks no altera los campos existentes del dict
+    de temporada (a, e, m, w, gd) — salen bit-idénticos.
+
+No requiere pandas/numpy: importa solo los helpers puros de update.py.
+"""
+import copy
+from update import (
+    TIEBREAKERS,
+    compute_league_ranks,
+    attach_ranks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers de fixture sintético
+# ---------------------------------------------------------------------------
+def standings(matches):
+    """Calcula los totales de temporada {team: {pts,gd,gf,gf_away,wins,wins_away}}
+    a partir de una lista de partidos (home, away, home_goals, away_goals).
+    Espeja la agregación de process_season en update.py."""
+    st = {}
+
+    def ensure(t):
+        st.setdefault(t, {'pts': 0, 'gd': 0, 'gf': 0, 'gf_away': 0,
+                          'wins': 0, 'wins_away': 0})
+
+    for (h, a, hg, ag) in matches:
+        ensure(h); ensure(a)
+        st[h]['gf'] += hg; st[h]['gd'] += hg - ag
+        st[a]['gf'] += ag; st[a]['gd'] += ag - hg; st[a]['gf_away'] += ag
+        if hg > ag:
+            st[h]['pts'] += 3; st[h]['wins'] += 1
+        elif ag > hg:
+            st[a]['pts'] += 3; st[a]['wins'] += 1; st[a]['wins_away'] += 1
+        else:
+            st[h]['pts'] += 1; st[a]['pts'] += 1
+    return st
+
+
+def top_up(matches, team, n_wins, n_draws, gf_per_win=2, tag=''):
+    """Añade partidos contra rivales de relleno ÚNICOS (cada uno juega un solo
+    partido, así nunca empatan con los contendientes) para sumar puntos de forma
+    controlada: n_wins victorias `gf_per_win`-0 y n_draws empates 1-1.
+    Suma 3*n_wins + n_draws puntos al equipo. Devuelve la lista de partidos."""
+    added = []
+    for k in range(n_wins):
+        added.append((team, f'F_{team}{tag}_w{k}', gf_per_win, 0))
+    for k in range(n_draws):
+        added.append((team, f'F_{team}{tag}_d{k}', 1, 1))
+    matches.extend(added)
+    return added
+
+
+def ranks_of(matches, lg):
+    return compute_league_ranks(standings(matches), matches, lg)
+
+
+# ---------------------------------------------------------------------------
+# 6 tests unitarios, uno por liga
+# ---------------------------------------------------------------------------
+def test_la_liga_triple_empate_mini_liga():
+    """La Liga: particular puntos -> particular GD -> general GD -> goles marcados.
+    Triple empate (A, B, C) a puntos, resuelto por PUNTOS de la mini-liga."""
+    m = [
+        # Mini-liga A,B,C (doble round-robin completo -> contorno (a) OK)
+        ('A', 'B', 2, 0), ('B', 'A', 0, 1),   # A gana ambos vs B
+        ('A', 'C', 1, 1), ('C', 'A', 0, 0),   # A y C empatan ambos
+        ('B', 'C', 3, 0), ('C', 'B', 1, 2),   # B gana ambos vs C
+    ]
+    # h2h puntos: A=8, B=6, C=2. Igualamos totales a 12 compensando con relleno.
+    top_up(m, 'A', 1, 1)   # +4 -> 12
+    top_up(m, 'B', 2, 0)   # +6 -> 12
+    top_up(m, 'C', 3, 1)   # +10 -> 12
+    r = ranks_of(m, 'll')
+    assert r['A'] == 1 and r['B'] == 2 and r['C'] == 3, r
+
+
+def test_serie_a_particular_gd():
+    """Serie A: misma cadena que La Liga. Empate a puntos y a PUNTOS de la
+    mini-liga -> resuelve la DIFERENCIA de goles particular (A > C > B)."""
+    m = [
+        ('A', 'B', 5, 0), ('B', 'A', 1, 0),   # split, h2h_gd: A +4, B -4
+        ('B', 'C', 3, 0), ('C', 'B', 1, 0),   # split, h2h_gd: B +2, C -2
+        ('C', 'A', 2, 0), ('A', 'C', 1, 0),   # split, h2h_gd: C +1, A -1
+    ]
+    # h2h puntos todos = 6 (2 victorias, 2 derrotas). h2h_gd: A=+3, C=-1, B=-2.
+    top_up(m, 'A', 0, 2)   # +2 -> 8
+    top_up(m, 'B', 0, 2)   # +2 -> 8
+    top_up(m, 'C', 0, 2)   # +2 -> 8
+    r = ranks_of(m, 'sa')
+    assert r['A'] == 1 and r['C'] == 2 and r['B'] == 3, r
+
+
+def test_premier_general_luego_particular():
+    """Premier: general GD -> goles marcados -> particular puntos -> particular
+    goles fuera. Un trío se separa por goles marcados generales; un par que
+    empata en TODO lo general se separa por goles marcados fuera particulares."""
+    # A,B,C: cada uno 2 victorias con MISMO GD general (+4) y goles marcados distintos.
+    m = [
+        ('A', 'FA1', 4, 2), ('A', 'FA2', 4, 2),   # A: 6pts, gd+4, gf8
+        ('B', 'FB1', 3, 1), ('B', 'FB2', 3, 1),   # B: 6pts, gd+4, gf6
+        ('C', 'FC1', 2, 0), ('C', 'FC2', 2, 0),   # C: 6pts, gd+4, gf4
+        # G,H: empatan a puntos(3), GD(0), gf(3) y a puntos particulares (3);
+        # solo los separa los GOLES MARCADOS FUERA particulares (G marca 1 fuera, H 0).
+        ('G', 'H', 2, 0), ('H', 'G', 3, 1),
+    ]
+    r = ranks_of(m, 'pl')
+    assert r['A'] == 1 and r['B'] == 2 and r['C'] == 3, r
+    st = standings(m)
+    assert st['G']['pts'] == st['H']['pts'] and st['G']['gd'] == st['H']['gd'] \
+        and st['G']['gf'] == st['H']['gf']
+    assert r['G'] == 4 and r['H'] == 5, r
+
+
+def test_bundesliga_particular_agregado():
+    """Bundesliga: general GD -> goles marcados -> particular (agregado=GD) ->
+    particular goles fuera -> goles fuera general. A y B empatan a puntos,
+    GD general y goles marcados; los separa el GD particular (A > B)."""
+    m = [
+        ('A', 'B', 3, 1), ('B', 'A', 1, 1),   # h2h_gd: A +2, B -2
+    ]
+    # A: pts4 gd+2 gf4 ; B: pts1 gd-2 gf2. Igualamos a pts10, gd+2, gf10.
+    top_up(m, 'A', 0, 6)                        # 6 empates 1-1: +6pts, gd0, gf+6 -> pts10 gd+2 gf10
+    m += [('B', 'FBw0', 2, 0), ('B', 'FBw1', 2, 0),           # +6pts, gd+4, gf+4
+          ('B', 'FBd0', 2, 2), ('B', 'FBd1', 1, 1), ('B', 'FBd2', 1, 1)]  # +3pts, gd0, gf+4
+    # B: pts 1+9=10, gd -2+4=+2, gf 2+8=10
+    r = ranks_of(m, 'bl')
+    st = standings(m)
+    assert st['A']['pts'] == st['B']['pts'] == 10
+    assert st['A']['gd'] == st['B']['gd'] and st['A']['gf'] == st['B']['gf']
+    assert r['A'] == 1 and r['B'] == 2, r
+
+
+def test_ligue1_particular_puntos():
+    """Ligue 1: general GD -> particular puntos -> particular GD -> goles
+    marcados -> victorias -> victorias fuera. A y B empatan a puntos y GD
+    general; los separa los PUNTOS particulares (A gana el head-to-head)."""
+    m = [
+        ('A', 'B', 1, 0), ('B', 'A', 0, 0),   # h2h pts: A 4, B 1
+    ]
+    # A: pts4 gd+1 ; B: pts1 gd-1. Igualamos a pts10, gd+1.
+    top_up(m, 'A', 0, 6)                        # +6pts, gd0 -> pts10 gd+1
+    m += [('B', 'FBw0', 1, 0), ('B', 'FBw1', 1, 0),            # +6pts, gd+2
+          ('B', 'FBd0', 0, 0), ('B', 'FBd1', 0, 0), ('B', 'FBd2', 0, 0)]  # +3pts, gd0
+    # B: pts 1+9=10, gd -1+2=+1
+    r = ranks_of(m, 'l1')
+    st = standings(m)
+    assert st['A']['pts'] == st['B']['pts'] == 10 and st['A']['gd'] == st['B']['gd']
+    assert r['A'] == 1 and r['B'] == 2, r
+
+
+def test_eredivisie_goles_marcados():
+    """Eredivisie: general GD -> goles marcados -> particular. A y B empatan a
+    puntos y GD general; los separa los GOLES MARCADOS generales (A > B)."""
+    m = []
+    m += [('A', 'FAw0', 4, 2), ('A', 'FAw1', 4, 2),           # A: +6pts gd+4 gf8
+          ('A', 'FAd0', 2, 2), ('A', 'FAd1', 2, 2),
+          ('A', 'FAd2', 2, 2), ('A', 'FAd3', 2, 2)]           # +4pts gd0 gf8 -> pts10 gd+4 gf16
+    m += [('B', 'FBw0', 2, 0), ('B', 'FBw1', 2, 0),           # B: +6pts gd+4 gf4
+          ('B', 'FBd0', 0, 0), ('B', 'FBd1', 0, 0),
+          ('B', 'FBd2', 0, 0), ('B', 'FBd3', 0, 0)]           # +4pts gd0 gf0 -> pts10 gd+4 gf4
+    r = ranks_of(m, 'ed')
+    st = standings(m)
+    assert st['A']['pts'] == st['B']['pts'] == 10 and st['A']['gd'] == st['B']['gd']
+    assert st['A']['gf'] > st['B']['gf']
+    assert r['A'] == 1 and r['B'] == 2, r
+
+
+# ---------------------------------------------------------------------------
+# Contorno (a): enfrentamientos incompletos -> criterios generales
+# ---------------------------------------------------------------------------
+def test_contorno_a_incompletos_saltan_a_generales():
+    """La Liga (particular-first). A y B empatan a puntos pero solo se han
+    enfrentado UNA vez (ida y vuelta incompletas): los criterios particulares
+    se saltan y decide el GD general. A ganaría el head-to-head, pero B tiene
+    mejor GD general -> B debe quedar por delante."""
+    m = [('A', 'B', 1, 0)]                      # solo un enfrentamiento
+    top_up(m, 'A', 0, 7)                        # A: +7pts (empates 1-1) -> pts10, gd+1
+    m += [('B', 'FBw0', 5, 0), ('B', 'FBw1', 5, 0), ('B', 'FBw2', 5, 0),
+          ('B', 'FBd0', 0, 0)]                  # B: +10pts, gd+15 -> pts10, gd+14
+    r = ranks_of(m, 'll')
+    st = standings(m)
+    assert st['A']['pts'] == st['B']['pts'] == 10
+    assert st['B']['gd'] > st['A']['gd']
+    # Si el particular se aplicara, A (ganó el h2h) iría delante. Contorno (a) lo impide:
+    assert r['B'] == 1 and r['A'] == 2, r
+
+
+# ---------------------------------------------------------------------------
+# Integridad: rank es permutación 1..N en toda liga x temporada del fixture
+# ---------------------------------------------------------------------------
+def _all_league_fixtures():
+    """Reconstruye los fixtures de los tests unitarios, uno por liga."""
+    fx = {}
+
+    m = [('A', 'B', 2, 0), ('B', 'A', 0, 1), ('A', 'C', 1, 1), ('C', 'A', 0, 0),
+         ('B', 'C', 3, 0), ('C', 'B', 1, 2)]
+    top_up(m, 'A', 1, 1); top_up(m, 'B', 2, 0); top_up(m, 'C', 3, 1)
+    fx['ll'] = m
+
+    m = [('A', 'B', 5, 0), ('B', 'A', 1, 0), ('B', 'C', 3, 0), ('C', 'B', 1, 0),
+         ('C', 'A', 2, 0), ('A', 'C', 1, 0)]
+    top_up(m, 'A', 0, 2); top_up(m, 'B', 0, 2); top_up(m, 'C', 0, 2)
+    fx['sa'] = m
+
+    fx['pl'] = [('A', 'FA1', 4, 2), ('A', 'FA2', 4, 2), ('B', 'FB1', 3, 1),
+                ('B', 'FB2', 3, 1), ('C', 'FC1', 2, 0), ('C', 'FC2', 2, 0),
+                ('G', 'H', 2, 0), ('H', 'G', 3, 1)]
+
+    m = [('A', 'B', 3, 1), ('B', 'A', 1, 1)]
+    top_up(m, 'A', 0, 6)
+    m += [('B', 'FBw0', 2, 0), ('B', 'FBw1', 2, 0), ('B', 'FBd0', 2, 2),
+          ('B', 'FBd1', 1, 1), ('B', 'FBd2', 1, 1)]
+    fx['bl'] = m
+
+    m = [('A', 'B', 1, 0), ('B', 'A', 0, 0)]
+    top_up(m, 'A', 0, 6)
+    m += [('B', 'FBw0', 1, 0), ('B', 'FBw1', 1, 0), ('B', 'FBd0', 0, 0),
+          ('B', 'FBd1', 0, 0), ('B', 'FBd2', 0, 0)]
+    fx['l1'] = m
+
+    m = [('A', 'FAw0', 4, 2), ('A', 'FAw1', 4, 2), ('A', 'FAd0', 2, 2),
+         ('A', 'FAd1', 2, 2), ('A', 'FAd2', 2, 2), ('A', 'FAd3', 2, 2),
+         ('B', 'FBw0', 2, 0), ('B', 'FBw1', 2, 0), ('B', 'FBd0', 0, 0),
+         ('B', 'FBd1', 0, 0), ('B', 'FBd2', 0, 0), ('B', 'FBd3', 0, 0)]
+    fx['ed'] = m
+    return fx
+
+
+def test_integridad_permutacion_completa():
+    """rank debe ser una permutación exacta 1..N en cada liga x temporada."""
+    for lg, m in _all_league_fixtures().items():
+        r = compute_league_ranks(standings(m), m, lg)
+        n = len(standings(m))
+        assert len(r) == n, (lg, len(r), n)
+        assert sorted(r.values()) == list(range(1, n + 1)), (lg, sorted(r.values()))
+
+
+# ---------------------------------------------------------------------------
+# No-regresión: attach_ranks no altera los campos existentes del dict
+# ---------------------------------------------------------------------------
+def test_no_regresion_campos_bit_identicos():
+    """attach_ranks añade 'rank' pero deja a/e/m/w/gd bit-idénticos."""
+    # Dict de temporada representativo (como el que emite process_season).
+    season_before = {
+        'A': {'a': [3, 6, 9], 'e': [1.2, 2.4, 3.6], 'm': [['B', 1, 3, 1.5]],
+              'w': 120, 'gd': 5},
+        'B': {'a': [0, 1, 4], 'e': [1.1, 2.0, 2.9], 'm': [['A', 0, 0, 0.9]],
+              'w': 80, 'gd': -3},
+    }
+    matches = [('A', 'B', 2, 0), ('B', 'A', 1, 1)]
+    stats = standings(matches)
+    # Alinear puntos con el dict de temporada (a[-1]) para un caso realista.
+    stats['A']['pts'] = season_before['A']['a'][-1]
+    stats['B']['pts'] = season_before['B']['a'][-1]
+
+    snapshot = copy.deepcopy(season_before)
+    season_after = attach_ranks(season_before, stats, matches, 'll')
+
+    for t in snapshot:
+        for field in ('a', 'e', 'm', 'w', 'gd'):
+            assert season_after[t][field] == snapshot[t][field], (t, field)
+        assert 'rank' in season_after[t] and isinstance(season_after[t]['rank'], int)
+    assert sorted(season_after[t]['rank'] for t in season_after) == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+if __name__ == '__main__':
+    tests = [
+        test_la_liga_triple_empate_mini_liga,
+        test_serie_a_particular_gd,
+        test_premier_general_luego_particular,
+        test_bundesliga_particular_agregado,
+        test_ligue1_particular_puntos,
+        test_eredivisie_goles_marcados,
+        test_contorno_a_incompletos_saltan_a_generales,
+        test_integridad_permutacion_completa,
+        test_no_regresion_campos_bit_identicos,
+    ]
+    for t in tests:
+        t()
+    print(f'OK: {len(tests)} tests de desempate ADR-005 pasan')

--- a/update.py
+++ b/update.py
@@ -11,11 +11,15 @@ Usage: python update.py
        FOOTBALL_DATA_API_KEY=xxx python update.py  (to update fixtures from API)
 Requirements: pip install pandas numpy scipy requests
 """
-import pandas as pd
-import numpy as np
-from scipy.special import expit
-import json, os, requests, sys
+import json, os, sys
 from datetime import datetime
+try:
+    import pandas as pd
+    import numpy as np
+    from scipy.special import expit
+    import requests
+except ImportError:  # permite importar los helpers puros (TIEBREAKERS, compute_league_ranks) sin las deps pesadas (tests)
+    pd = np = expit = requests = None
 
 # ============================================================
 # SEASON — auto-derived from current date with safety check
@@ -33,6 +37,40 @@ PARAMS = {
     'l1': {'beta': 0.4237, 'theta1': -0.8941, 'theta2': 0.2411},
     'ed': {'beta': 0.61,   'theta1': -0.9014, 'theta2': 0.2038},
 }
+
+# ============================================================
+# ADR-005 — NO modificar sin mandato explícito (zona de rigor spec §3.1)
+# Cadena de desempate de la clasificación real por liga, aplicada TRAS los
+# puntos. Fuente normativa: decisions.md ADR-005 §Decisión (tabla verbatim).
+# Las claves de liga son las internas (ll, pl, sa, bl, l1, ed).
+# Semántica cerrada de cada criterio (ver compute_league_ranks):
+#   h2h_pts     particular: puntos en la mini-liga de TODOS los empatados
+#   h2h_gd      particular: diferencia de goles en esa mini-liga  (= "particular (agregado)")
+#   h2h_gf      particular: goles marcados en esa mini-liga
+#   h2h_gf_away particular: goles marcados fuera en esa mini-liga
+#   gen_gd      general:    diferencia de goles de la temporada
+#   gen_gf      general:    goles marcados en la temporada
+#   gen_gf_away general:    goles marcados fuera en la temporada
+#   wins        general:    victorias en la temporada
+#   wins_away   general:    victorias fuera en la temporada
+# Mapeo verbatim ADR-005 -> claves:
+#   La Liga / Serie A:  particular puntos -> particular GD -> general GD -> goles marcados
+#   Premier:            general GD -> goles marcados -> particular puntos -> particular goles fuera
+#   Bundesliga:         general GD -> goles marcados -> particular (agregado=GD) -> particular goles fuera -> goles fuera general
+#   Ligue 1:            general GD -> particular puntos -> particular GD -> goles marcados -> victorias -> victorias fuera
+#   Eredivisie:         general GD -> goles marcados -> particular (mini-liga: puntos -> GD -> goles marcados)
+# ============================================================
+TIEBREAKERS = {
+    'll': ['h2h_pts', 'h2h_gd', 'gen_gd', 'gen_gf'],
+    'sa': ['h2h_pts', 'h2h_gd', 'gen_gd', 'gen_gf'],
+    'pl': ['gen_gd', 'gen_gf', 'h2h_pts', 'h2h_gf_away'],
+    'bl': ['gen_gd', 'gen_gf', 'h2h_gd', 'h2h_gf_away', 'gen_gf_away'],
+    'l1': ['gen_gd', 'h2h_pts', 'h2h_gd', 'gen_gf', 'wins', 'wins_away'],
+    'ed': ['gen_gd', 'gen_gf', 'h2h_pts', 'h2h_gd', 'h2h_gf'],
+}
+
+_PARTICULAR_CRITERIA = frozenset({'h2h_pts', 'h2h_gd', 'h2h_gf', 'h2h_gf_away'})
+
 _CSV_YEAR = CURRENT_SEASON.replace('/', '')  # 'YY/NN' -> 'YYNN'
 _CSV_BASE = f'https://www.football-data.co.uk/mmz4281/{_CSV_YEAR}'
 
@@ -436,7 +474,8 @@ def process_season(filepath_or_df, wages, beta, t1, t2, fixtures_calendar=None, 
     
     td = {}
     for t in sorted(set(df['HomeTeam']) | set(df['AwayTeam'])):
-        td[t] = {'pts':[],'exp':[],'m':[],'cp':0,'ce':0.0,'gf':0,'ga':0}
+        td[t] = {'pts':[],'exp':[],'m':[],'cp':0,'ce':0.0,'gf':0,'ga':0,'gf_away':0,'wins':0,'wins_away':0}
+    season_matches = []  # (home, away, home_goals, away_goals) para desempates ADR-005
     for _, r in df.iterrows():
         h, a = r['HomeTeam'], r['AwayTeam']
         wh, wa = wages.get(h, wages.get(fix_name(h), wages.get('_min', 20))), wages.get(a, wages.get(fix_name(a), wages.get('_min', 20)))
@@ -455,12 +494,130 @@ def process_season(filepath_or_df, wages, beta, t1, t2, fixtures_calendar=None, 
         ag = int(r['FTAG']) if has_goals else 0
         td[h]['gf'] += hg; td[h]['ga'] += ag
         td[a]['gf'] += ag; td[a]['ga'] += hg
+        # Extra season aggregates for ADR-005 tiebreakers (no alteran los campos emitidos)
+        td[a]['gf_away'] += ag
+        if r['FTR'] == 'H': td[h]['wins'] += 1
+        elif r['FTR'] == 'A': td[a]['wins'] += 1; td[a]['wins_away'] += 1
+        season_matches.append((h, a, hg, ag))
         for team, pts, exp, opp, ih in [(h,hp,eh,a,1),(a,ap,ea,h,0)]:
             td[team]['cp'] += pts; td[team]['ce'] += exp
             td[team]['pts'].append(td[team]['cp'])
             td[team]['exp'].append(round(td[team]['ce'], 1))
             td[team]['m'].append([opp, ih, pts, round(exp, 2), official_gw, mdate])
-    return {t: {'a':d['pts'],'e':d['exp'],'m':d['m'],'w':round(wages.get(t, wages.get(fix_name(t), 0))),'gd':d['gf']-d['ga']} for t,d in td.items()}
+    result = {t: {'a':d['pts'],'e':d['exp'],'m':d['m'],'w':round(wages.get(t, wages.get(fix_name(t), 0))),'gd':d['gf']-d['ga']} for t,d in td.items()}
+    stats = {t: {'pts': d['cp'], 'gd': d['gf']-d['ga'], 'gf': d['gf'],
+                 'gf_away': d['gf_away'], 'wins': d['wins'], 'wins_away': d['wins_away']}
+             for t, d in td.items()}
+    return attach_ranks(result, stats, season_matches, lg)
+
+
+# ============================================================
+# ADR-005 — clasificación real con desempate fino por liga.
+# Implementación única de la tabla normativa TIEBREAKERS (zona de rigor
+# spec §3.1). No modificar la semántica sin mandato explícito del issue.
+# ============================================================
+def _h2h_table(subset, matches):
+    """Mini-liga: agrega SOLO los partidos entre equipos del subset (N>=2).
+    Devuelve {team: {pts, gd, gf, gf_away}} sobre esos enfrentamientos."""
+    s = set(subset)
+    tab = {t: {'pts': 0, 'gd': 0, 'gf': 0, 'gf_away': 0} for t in subset}
+    for (h, a, hg, ag) in matches:
+        if h in s and a in s:
+            tab[h]['gf'] += hg; tab[h]['gd'] += hg - ag
+            tab[a]['gf'] += ag; tab[a]['gd'] += ag - hg
+            tab[a]['gf_away'] += ag
+            if hg > ag: tab[h]['pts'] += 3
+            elif ag > hg: tab[a]['pts'] += 3
+            else: tab[h]['pts'] += 1; tab[a]['pts'] += 1
+    return tab
+
+
+def _pairs_complete(subset, matches):
+    """Contorno (a) ADR-005: True solo si TODO par del subset ha completado
+    sus 2 enfrentamientos reglamentarios (ida y vuelta, un partido en cada campo)."""
+    s = set(subset)
+    seen = {}
+    for (h, a, hg, ag) in matches:
+        if h in s and a in s:
+            seen[(h, a)] = seen.get((h, a), 0) + 1
+    for i in subset:
+        for j in subset:
+            if i < j and (seen.get((i, j), 0) < 1 or seen.get((j, i), 0) < 1):
+                return False
+    return True
+
+
+def _stable_order(subset, stats):
+    """Contorno (b) ADR-005: cadena agotada -> orden estable previo del
+    producto (puntos -> GD general), con el nombre como último desempate
+    determinista para garantizar una permutación total."""
+    return sorted(subset, key=lambda t: (-stats[t]['pts'], -stats[t]['gd'], t))
+
+
+def _resolve(subset, criteria, matches, stats):
+    """Ordena `subset` (empatados en el paso anterior) aplicando la cadena
+    `criteria`. Si un criterio no separa a un subconjunto, el siguiente se
+    aplica SOLO dentro de ese subconjunto (recursión con la cola)."""
+    if len(subset) <= 1 or not criteria:
+        return _stable_order(subset, stats)
+    crit, rest = criteria[0], criteria[1:]
+    if crit in _PARTICULAR_CRITERIA and not _pairs_complete(subset, matches):
+        # Contorno (a): enfrentamientos incompletos -> se saltan TODOS los
+        # criterios particulares del subconjunto y se sigue con los generales.
+        generals = [c for c in criteria if c not in _PARTICULAR_CRITERIA]
+        return _resolve(subset, generals, matches, stats)
+
+    if crit in _PARTICULAR_CRITERIA:
+        tab = _h2h_table(subset, matches)  # mini-liga de TODOS los del subset
+        key = {'h2h_pts': 'pts', 'h2h_gd': 'gd', 'h2h_gf': 'gf', 'h2h_gf_away': 'gf_away'}[crit]
+        val = lambda t: tab[t][key]
+    else:
+        key = {'gen_gd': 'gd', 'gen_gf': 'gf', 'gen_gf_away': 'gf_away',
+               'wins': 'wins', 'wins_away': 'wins_away'}[crit]
+        val = lambda t: stats[t][key]
+
+    ordered = sorted(subset, key=lambda t: -val(t))
+    out, i = [], 0
+    while i < len(ordered):
+        j = i
+        while j < len(ordered) and val(ordered[j]) == val(ordered[i]):
+            j += 1
+        group = ordered[i:j]
+        out.extend(group if len(group) == 1 else _resolve(group, rest, matches, stats))
+        i = j
+    return out
+
+
+def compute_league_ranks(stats, matches, lg):
+    """Ranking oficial ADR-005: aplica puntos y luego la cadena TIEBREAKERS[lg].
+    stats:   {team: {pts, gd, gf, gf_away, wins, wins_away}} — totales de la temporada.
+    matches: iterable de (home, away, home_goals, away_goals) — partidos jugados.
+    Devuelve {team: rank} con rank entero en 1..N (permutación completa)."""
+    chain = TIEBREAKERS[lg]
+    matches = list(matches)
+    teams = sorted(stats.keys())  # nombre como base determinista antes de puntos
+    by_pts = sorted(teams, key=lambda t: -stats[t]['pts'])
+    order, i = [], 0
+    while i < len(by_pts):
+        j = i
+        while j < len(by_pts) and stats[by_pts[j]]['pts'] == stats[by_pts[i]]['pts']:
+            j += 1
+        group = by_pts[i:j]
+        order.extend(group if len(group) == 1 else _resolve(group, chain, matches, stats))
+        i = j
+    return {t: r + 1 for r, t in enumerate(order)}
+
+
+def attach_ranks(season, stats, matches, lg):
+    """Añade el campo `rank` (ADR-005) a cada equipo del dict de temporada SIN
+    tocar los campos existentes (a, e, m, w, gd). Devuelve el mismo dict.
+    No-op si `lg` no está en TIEBREAKERS (no hay cadena definida)."""
+    if lg not in TIEBREAKERS:
+        return season
+    ranks = compute_league_ranks(stats, matches, lg)
+    for t in season:
+        season[t]['rank'] = ranks.get(t)
+    return season
 
 
 def recalculate_budget_bands(fixtures_cal, wages, beta, t1, t2, lg, season_data, remaining_fixtures, n_sims=10000):


### PR DESCRIPTION
Implementa el motor de desempate fino de la clasificación real (ADR-005, épica desempates 1/2).

- Constante `TIEBREAKERS` por liga (claves internas ll/sa/pl/bl/l1/ed) con ancla `# ADR-005 — NO modificar sin mandato explícito` (zona de rigor spec §3.1).
- `compute_league_ranks`: puntos + cadena de desempate sobre la mini-liga de TODOS los empatados; subconjunto no separado → siguiente criterio solo dentro del subconjunto; cadena agotada → orden estable previo (contorno b). Contorno (a): enfrentamientos incompletos → se saltan los particulares del subconjunto.
- `process_season` emite `rank` (permutación 1..N) sin alterar `a/e/m/w/gd`, puntos, MC ni presupuesto (bit-idénticos, req. 4).
- `test_tiebreakers.py`: 9 tests standalone (verde).

**Backfill histórico: fuera de alcance de agente** (resolución autónoma en #7): las temporadas históricas de `data.json` no guardan goles y `data.json` no lo toca un agente (CLAUDE.md + ADR-002); es una corrida de datos del mantenedor/cron. El motor emite `rank` para toda temporada que se procese con datos de goles.

Closes #7

<!-- full-pr -->

_PR creado mecánicamente por el Architect (OK del propietario en sesión): desbloqueo de la clase de fallo «PR huérfano» — Creator success + rama con trabajo + cero PRs. La sesión re-armada no puede abrir PR de una rama ajena a su checkout; propuesta de fix mecánico en el watchdog pendiente._