### PR TITLE
Promote: fixes #79 (validación CSV fallback) y #80 (seeding calendario en process_season)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -20,7 +20,6 @@ jobs:
     with:
       runner: ubuntu-latest
       default_branch: develop
-      creator_model: claude-opus-4-8
       creator_max_turns: 100
       bot_comment_cap: 8
     secrets:

--- a/.github/workflows/epic-merge.yml
+++ b/.github/workflows/epic-merge.yml
@@ -7,6 +7,8 @@ on:
     types: [completed]
   pull_request:
     types: [closed, labeled]
+  issues:
+    types: [closed]
 permissions:
   contents: write
   pull-requests: write
@@ -14,7 +16,7 @@ permissions:
   statuses: write
   actions: read
 concurrency:
-  group: epic-merge-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref }}
+  group: epic-merge-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref || github.event.issue.number }}
   cancel-in-progress: false
 jobs:
   call:

--- a/.github/workflows/process-review.yml
+++ b/.github/workflows/process-review.yml
@@ -15,8 +15,6 @@ jobs:
     with:
       runner: ubuntu-latest
       default_branch: develop
-      process_model: claude-fable-5
-      process_fallback_model: claude-opus-4-8
       process_max_turns: 60
       timeout_minutes: 20
     secrets:

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -16,7 +16,6 @@ jobs:
     uses: talfarouriarte-cloud/agent-pipeline/.github/workflows/reviewer.yml@main
     with:
       runner: ubuntu-latest
-      reviewer_model: claude-opus-4-8
       reviewer_max_turns: 50
       timeout_minutes: 15
       agent_branch_prefix: claude/

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -34,7 +34,6 @@ jobs:
       epic_merge_workflow_name: Epic Merge
       extra_pipeline_workflows: ""
       epic_label: epica
-      resolve_model: claude-opus-4-8
       resolve_max_turns: 40
       lookback_min: 45
     secrets:

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -13,7 +13,7 @@ GitHub Actions runs `update.py` four times daily — crons at 00:00, 00:02, 06:0
 1. Detects current season from date: **July 15+ = new season** (ADR-008; single derivation in `derive_season()`, `update.py`)
 2. Loads wages from `all_wages.json` (missing teams filled from previous season; promoted teams get league minimum)
 3. Fetches fixture calendar + match results from football-data.org API (real-time, minutes after final whistle). Guard (ADR-007): if a league's calendar payload doesn't match `CURRENT_SEASON`, that league is discarded and picked up by a later cron once published.
-4. Downloads match results CSVs from football-data.co.uk as fallback (1-2 day delay)
+4. Downloads match results CSVs from football-data.co.uk as fallback (1-2 day delay). Guard (issue #79, twin of ADR-007 on the CSV path): the request uses `allow_redirects=False` and any status ≠ 200 discards the league; the body is then validated (`validate_csv_content`) so its `Div` column matches the requested league and the first `Date` falls in `CURRENT_SEASON`. This blocks football-data.co.uk's fuzzy-redirect to the "closest" file of another league and its HTML 300 bodies when the season's CSV doesn't exist yet. A discarded league logs one of two literals depending on the branch: `FAILED: status <n> (url <url>) — redirect/HTML rechazado` when status ≠ 200 (the 3xx fuzzy-redirect and the HTML 300), or `WARNING: contenido inválido para <lg> ... descartado` when a 200 body fails the league/season validation. In both cases the league is picked up by a later cron once the real CSV is published.
 5. Computes expected points, MC bands, budget forecast, position probabilities, narratives
 6. Runs diagnostic checks (budget line parallelism)
 7. Commits updated `data.json` and `fixtures.json` to `main`
@@ -22,7 +22,7 @@ After every successful run, `build-crests.yml` is triggered automatically via `w
 
 ### Data source priority
 1. **football-data.org API** (primary): scores available minutes after matches. 6 API calls, well within free tier limit (10/min).
-2. **football-data.co.uk CSV** (fallback): updated Sunday/Wednesday nights. Used if API key missing or API fails.
+2. **football-data.co.uk CSV** (fallback): updated Sunday/Wednesday nights. Used if API key missing or API fails **and** the downloaded CSV passes the league+season validation above (issue #79); otherwise the league is discarded, not ingested.
 
 ### Budget forecast
 Both updated and budget p50 use deterministic expected value (`pw×3 + pd`). MC only for p10/p90 bands. Guarantees parallel projected lines.
@@ -128,6 +128,8 @@ p50 = deterministic, p10/p90 = MC percentile.
 | 0 remaining fixtures | Name mapping mismatch | Add to `api_to_internal` in `name_map.json` |
 | Production data stale but crons green | Cron committing to wrong branch | `update.yml` checkout must carry `ref: main` (ADR-002); schedule runs from default branch (`develop`) |
 | A league missing after July 15 | Its new calendar not published yet | Normal (ADR-007 guard); daily cron picks it up when the API serves it |
+| `FAILED: status <n> (url <url>) — redirect/HTML rechazado` in cron log | football-data.co.uk served a 3xx fuzzy-redirect (to another league's file) or an HTML 300 instead of the season's CSV (not published yet) | Normal (issue #79 guard, status ≠ 200 branch); daily cron picks it up when the real CSV appears |
+| `WARNING: contenido inválido para <lg> ... descartado` in cron log | football-data.co.uk returned a 200 body that failed validation: another league's `Div` or a past-season date | Normal (issue #79 guard, body-rejected branch); daily cron picks it up when the real CSV appears |
 | Tooltips stuck on iPad | Recharts pointer-events | Fixed: global touch handler |
 | Results not updating | API key missing or expired | Check `FOOTBALL_DATA_API_KEY` secret in repo |
 | GW X -> X (no new matches) | Source not updated yet | API: minutes; CSV: Sun/Wed night |

--- a/test_csv_validation.py
+++ b/test_csv_validation.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Tests de la validación de CSV descargado en download_current_season (issue #79).
+
+Agujero: cuando el CSV de la temporada aún no existe, football-data.co.uk NO
+devuelve 404 consistente — a veces hace fuzzy-redirect (3xx) al fichero «más
+parecido» de OTRA liga, a veces devuelve 300 con cuerpo HTML. El código antiguo
+(`requests.get(url, timeout=30)` + `raise_for_status()`) seguía la redirección
+y no fallaba con 3xx, así que ingería el CSV escocés como La Liga y el HTML
+reventaba `process_season`.
+
+Contrato verificado (issue #79):
+  1. `allow_redirects=False` y cualquier status != 200 => results[lg] = None.
+  2. Validación de contenido: primera columna `Div` (BOM-tolerante) y valor de
+     `Div` en datos == código esperado de la liga (derivado de URLS).
+  3. Con results[lg] = None el flujo cae en las ramas existentes (no probado
+     aquí: es integración de update_data; aquí se prueba el punto de decisión).
+
+DoD del issue: CSV con Div incorrecto => None; CSV con HTML => None; CSV válido
+con BOM => aceptado. Sin red ni pandas: monkeypatch de update.requests.
+
+Ejecutable standalone con exit code (asserts):
+    python3 test_csv_validation.py
+"""
+import contextlib
+import os
+import tempfile
+
+import update
+
+CS_DIV = update.EXPECTED_DIV  # ll->SP1, pl->E0, ...
+_START_YEAR = 2000 + int(update.CURRENT_SEASON.split('/')[0])
+
+
+def _valid_csv(div, year=None):
+    """CSV mínimo válido de `div` con fechas en la temporada dada (por defecto la
+    actual), para que los tests de integración sigan la ventana de temporada del
+    validador (nit #4) sin depender de un año hardcodeado."""
+    y = _START_YEAR if year is None else year
+    return (
+        "Div,Date,HomeTeam,AwayTeam,FTHG,FTAG,FTR\n"
+        f"{div},15/08/{y},A,B,1,0,H\n"
+        f"{div},16/08/{y},C,D,0,0,D\n"
+    )
+
+# --- CSVs sintéticos ---------------------------------------------------------
+VALID_SP1 = (
+    "Div,Date,HomeTeam,AwayTeam,FTHG,FTAG,FTR\n"
+    "SP1,15/08/2026,Barcelona,Real Madrid,2,1,H\n"
+    "SP1,16/08/2026,Sevilla,Valencia,0,0,D\n"
+)
+# Mismo contenido pero con BOM UTF-8 al inicio (football-data lo sirve así a
+# menudo). Dos formas que hay que tolerar:
+#   - U+FEFF: cuando requests decodifica el cuerpo como utf-8.
+#   - `ï»¿` (mojibake): los tres bytes del BOM UTF-8 leídos como latin-1, que
+#     es lo que ocurre en el cron real y la forma que el issue #79 cita literal.
+VALID_SP1_BOM = "﻿" + VALID_SP1
+VALID_SP1_BOM_MOJIBAKE = "ï»¿" + VALID_SP1
+# Fuzzy-redirect: CSV del Championship escocés (SC1) servido en la URL de SP1.
+WRONG_LEAGUE_SC1 = (
+    "Div,Date,HomeTeam,AwayTeam,FTHG,FTAG,FTR\n"
+    "SC1,08/08/2026,Arbroath,Ayr,1,3,A\n"
+    "SC1,09/08/2026,Dunfermline,Falkirk,2,2,D\n"
+)
+# Status 300 con cuerpo HTML (lo que pasa hoy con I1/D1/F1).
+HTML_300 = (
+    "<!DOCTYPE html>\n<html><head><title>300 Multiple Choices</title></head>\n"
+    "<body><h1>Multiple Choices</h1></body></html>\n"
+)
+
+
+def test_valid_csv_accepted():
+    ok, reason = update.validate_csv_content(VALID_SP1, 'SP1')
+    assert ok, f"CSV válido de SP1 debe aceptarse, got reason={reason!r}"
+    print("OK CSV válido (Div=SP1) aceptado")
+
+
+def test_valid_csv_with_bom_accepted():
+    """DoD: CSV válido con BOM => aceptado. Ambas formas (U+FEFF y el mojibake
+    `ï»¿` que el issue #79 cita literal y que produce el cron real)."""
+    ok, reason = update.validate_csv_content(VALID_SP1_BOM, 'SP1')
+    assert ok, f"CSV válido con BOM U+FEFF debe aceptarse, got reason={reason!r}"
+    ok_m, reason_m = update.validate_csv_content(VALID_SP1_BOM_MOJIBAKE, 'SP1')
+    assert ok_m, f"CSV válido con BOM mojibake ï»¿ debe aceptarse, got reason={reason_m!r}"
+    print("OK CSV válido con BOM aceptado (U+FEFF y mojibake ï»¿)")
+
+
+def test_wrong_league_rejected():
+    """DoD: CSV con Div incorrecto (fuzzy-redirect a otra liga) => None."""
+    ok, reason = update.validate_csv_content(WRONG_LEAGUE_SC1, 'SP1')
+    assert not ok, "CSV de otra liga (SC1) NO debe aceptarse como SP1"
+    assert 'SC1' in reason and 'SP1' in reason, \
+        f"el motivo debe citar Div encontrado y esperado, got {reason!r}"
+    print(f"OK CSV de otra liga rechazado ({reason})")
+
+
+def test_html_rejected():
+    """DoD: cuerpo HTML (status 300) => None."""
+    ok, reason = update.validate_csv_content(HTML_300, 'I1')
+    assert not ok, "un cuerpo HTML NO debe aceptarse como CSV"
+    assert 'Div' in reason, f"el motivo debe señalar columna != Div, got {reason!r}"
+    print(f"OK cuerpo HTML rechazado ({reason})")
+
+
+def test_empty_and_headeronly_rejected():
+    assert not update.validate_csv_content("", 'SP1')[0], "vacío => rechazado"
+    assert not update.validate_csv_content("Div,Date,HomeTeam\n", 'SP1')[0], \
+        "solo header sin filas de datos => rechazado"
+    print("OK vacío y solo-header rechazados")
+
+
+def test_wrong_season_rejected():
+    """Nit #4: liga correcta pero temporada PASADA (fuzzy-match a /2526/) => None.
+    El `Div` coincide, así que solo el ancla de temporada puede rechazarlo."""
+    past = _valid_csv('SP1', year=_START_YEAR - 1)
+    ok, reason = update.validate_csv_content(past, 'SP1', update.CURRENT_SEASON)
+    assert not ok, "CSV de la temporada pasada NO debe aceptarse como actual"
+    assert str(_START_YEAR - 1) in reason, \
+        f"el motivo debe citar el año fuera de ventana, got {reason!r}"
+    ok_cur, _ = update.validate_csv_content(
+        _valid_csv('SP1'), 'SP1', update.CURRENT_SEASON)
+    assert ok_cur, "CSV de la temporada actual debe aceptarse"
+    # Sin expected_season el ancla no aplica (retrocompatible).
+    ok_no, _ = update.validate_csv_content(past, 'SP1')
+    assert ok_no, "sin expected_season la temporada no se comprueba"
+    print(f"OK temporada pasada rechazada ({reason})")
+
+
+def test_expected_div_derived_from_urls():
+    """El mapeo esperado se deriva de URLS, no se hardcodea aparte."""
+    assert CS_DIV == {
+        'll': 'SP1', 'pl': 'E0', 'sa': 'I1',
+        'bl': 'D1', 'l1': 'F1', 'ed': 'N1',
+    }, f"EXPECTED_DIV inesperado: {CS_DIV}"
+    print("OK EXPECTED_DIV derivado de URLS")
+
+
+class _FakeResp:
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeRequests:
+    """Sustituye a update.requests: sirve por URL y registra kwargs."""
+    def __init__(self, by_url):
+        self.by_url = by_url
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        status, text = self.by_url[url]
+        return _FakeResp(status, text)
+
+
+@contextlib.contextmanager
+def _run_download_with(by_url):
+    """Corre download_current_season con requests/DATA_DIR monkeypatcheados.
+    `TemporaryDirectory` limpia el tmp al salir del `with` y el `finally`
+    restaura los globals — las tres cosas se cierran juntas (nit #5). Las
+    aserciones sobre ficheros escritos van DENTRO del `with`, antes de la
+    limpieza."""
+    orig_req = update.requests
+    orig_dir = update.DATA_DIR
+    fake = _FakeRequests(by_url)
+    with tempfile.TemporaryDirectory() as tmp:
+        update.requests = fake
+        update.DATA_DIR = tmp
+        try:
+            results = update.download_current_season()
+            yield results, fake, tmp
+        finally:
+            update.requests = orig_req
+            update.DATA_DIR = orig_dir
+
+
+def test_download_passes_allow_redirects_false():
+    """Contrato 1: allow_redirects=False en cada requests.get."""
+    # Todas las ligas con el generador anclado a update.CURRENT_SEASON (nit #1
+    # ronda 2): VALID_SP1 lleva el año literal 2026 y, con el ancla de temporada
+    # activa en download_current_season, rompería la rama `ll` en cuanto
+    # CURRENT_SEASON avance (2027-07-15). VALID_SP1 sigue sirviendo a los tests
+    # unitarios de validate_csv_content (2 args, sin ancla), donde el año es inocuo.
+    by_url = {url: (200, _valid_csv(update.EXPECTED_DIV[lg]))
+              for lg, url in update.URLS.items()}
+    with _run_download_with(by_url) as (results, fake, tmp):
+        assert all(kw.get('allow_redirects') is False for _, kw in fake.calls), \
+            "cada requests.get debe pasar allow_redirects=False"
+        # Todas las ligas válidas => path escrito y fichero en disco.
+        for lg in update.URLS:
+            assert results[lg] is not None, f"{lg} válido debe devolver path"
+            assert os.path.exists(results[lg]), f"{lg}: el CSV debe escribirse"
+    print("OK download: allow_redirects=False y CSVs válidos escritos")
+
+
+def test_download_rejects_redirect_and_wrong_league_and_html():
+    """Contrato 1+2: 3xx => None; otra liga => None; HTML(300) => None."""
+    urls = update.URLS
+    by_url = {
+        urls['ll']: (301, ""),                 # redirect => None
+        urls['pl']: (200, WRONG_LEAGUE_SC1),   # 200 pero otra liga => None
+        urls['sa']: (300, HTML_300),           # HTML 300 => None
+        urls['bl']: (200, _valid_csv('D1')),   # válido (temporada actual)
+        urls['l1']: (200, _valid_csv('F1')),   # válido (temporada actual)
+        urls['ed']: (404, ""),                 # 404 => None
+    }
+    with _run_download_with(by_url) as (results, fake, tmp):
+        assert results['ll'] is None, "301 redirect => None"
+        assert results['pl'] is None, "CSV de otra liga (SC1) => None"
+        assert results['sa'] is None, "HTML 300 => None"
+        assert results['ed'] is None, "404 => None"
+        assert results['bl'] is not None and os.path.exists(results['bl']), \
+            "D1 válido => path escrito"
+        assert results['l1'] is not None and os.path.exists(results['l1']), \
+            "F1 válido => path escrito"
+    print("OK download: redirect/otra-liga/HTML/404 => None; válidos escritos")
+
+
+if __name__ == '__main__':
+    test_valid_csv_accepted()
+    test_valid_csv_with_bom_accepted()
+    test_wrong_league_rejected()
+    test_html_rejected()
+    test_empty_and_headeronly_rejected()
+    test_wrong_season_rejected()
+    test_expected_div_derived_from_urls()
+    test_download_passes_allow_redirects_false()
+    test_download_rejects_redirect_and_wrong_league_and_html()
+    print("\nTODOS LOS TESTS OK (validación CSV, issue #79)")

--- a/test_preseason.py
+++ b/test_preseason.py
@@ -276,6 +276,53 @@ def test_preseason_ranks_permutation():
     print("OK (8) rank pre-season: permutación 1..N, mayor p50 => rank 1, desempates deterministas")
 
 
+def test_compute_position_probs_cur_equals_pre_preseason():
+    """(9) issue #76: en pre-season (0 jugados) las columnas POS de «Previsión
+    actualizada» (cur) y «Previsión presupuesto» (pre) son conceptualmente la
+    misma previsión. Dos simulaciones MC independientes divergían por ruido en
+    zonas apiñadas de la tabla (±1 puesto) aunque el p50 fuese idéntico. El
+    contrato: compute_all_position_probs NO llama a simulate_current_positions
+    en pre-season — asigna pos[lg][CS]['cur'] como DEEP COPY de ['pre'] y deja
+    hist=[]. En cuanto hay ≥1 jugado (_has_real_block True) vuelve el camino
+    normal."""
+    teams = [f'T{i:02d}' for i in range(16)]
+    cal = _synthetic_calendar(teams)
+    fx = {'ll': {CS: {'calendar': cal}}}
+    wages = {t: 100 - 3 * i for i, t in enumerate(teams)}
+
+    # Bloque pre-season: 0 jugados (a=[]) => _has_real_block(sd) es False.
+    sd = {t: {'a': [], 'e': [], 'm': [], 'gd': 0, 'w': wages[t]} for t in teams}
+    data = {'seasons': {lg: {} for lg in update.PARAMS}, 'pos': {}}
+    data['seasons']['ll'] = {CS: sd}
+
+    # load_wages sintético (sin all_wages.json ni red): el resto de ligas quedan
+    # vacías, así que compute_all_position_probs solo procesa 'll'.
+    orig_load = update.load_wages
+    update.load_wages = lambda lg, season, _cache={}: dict(wages)
+    try:
+        np.random.seed(0)
+        pos = update.compute_all_position_probs(data, fx)
+    finally:
+        update.load_wages = orig_load
+
+    block = pos['ll'][CS]
+    assert 'pre' in block and 'cur' in block, f"faltan pre/cur: {sorted(block)}"
+    assert set(block['cur'].keys()) == set(teams), \
+        "cur debe cubrir exactamente el roster del calendario"
+    # cur deep-equal a pre para TODOS los equipos (DoD del issue #76).
+    assert block['cur'] == block['pre'], \
+        "en pre-season cur debe ser deep-equal a pre (sin divergencia MC)"
+    # Deep copy, NO referencia compartida: mutar cur no debe tocar pre.
+    assert block['cur'] is not block['pre'], "cur no debe ser el MISMO objeto que pre"
+    a_team = teams[0]
+    block['cur'][a_team]['1st'] = -999.0
+    assert block['pre'][a_team]['1st'] != -999.0, \
+        "mutar cur no debe alterar pre (deep copy, no referencia compartida)"
+    # hist vacío en pre-season (0 jugados no aporta evolución por jornada).
+    assert block.get('hist') == [], f"hist debe ser [] en pre-season, got {block.get('hist')!r}"
+    print("OK (9) pre-season: cur == deep copy de pre; hist []")
+
+
 def test_guard_preserves_real_block_on_outage():
     """(7) Regresión 🔴 #1: con bloque real (N jugados) ya en data.json y sin
     fuente (API+CSV caídos a la vez), la rama pre-season NO se activa — se
@@ -324,5 +371,6 @@ if __name__ == '__main__':
     test_wage_status_stale_on_fallback()
     test_cumulative_ignores_zero_played()
     test_preseason_ranks_permutation()
+    test_compute_position_probs_cur_equals_pre_preseason()
     test_guard_preserves_real_block_on_outage()
-    print("\nTODOS LOS TESTS OK (pre-season, issue #59 + #69)")
+    print("\nTODOS LOS TESTS OK (pre-season, issue #59 + #69 + #76)")

--- a/test_process_season_calendar_seed.py
+++ b/test_process_season_calendar_seed.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Tests de `process_season` sembrando el universo de equipos desde el calendario
+(issue #80).
+
+Bug: con pocos resultados (p. ej. La Liga 26/27 a 2 partidos jugados) el bloque
+de CURRENT_SEASON quedaba SOLO con los equipos que aparecen en los resultados;
+los demás equipos de la liga desaparecían de la temporada actual. La causa:
+`process_season` construía `td` exclusivamente desde `df['HomeTeam']/AwayTeam`,
+sin usar el calendario (`fixtures_calendar`) que ya recibe para `gw_lookup`.
+
+Contrato (issue #80):
+  1. Con `fixtures_calendar` y `lg` disponibles y calendario de CURRENT_SEASON
+     con equipos, `td` se siembra con TODOS los equipos del calendario (vía
+     fix_name) además de los de `df`. Los equipos sin partidos jugados quedan
+     con las estructuras vacías (a=[], e=[], m=[], gd=0) — mismo estado que
+     build_preseason_block.
+  2. Los equipos CON partidos jugados conservan números IDÉNTICOS a los del
+     código previo (el sembrado no altera el núcleo numérico).
+  3. Sin calendario (ligas históricas, llamadas sin `lg`): comportamiento
+     previo intacto — `td` solo desde `df`, byte-idéntico.
+
+DoD: DataFrame de 2 partidos + calendario de 20 equipos → bloque de 20 equipos,
+y los 4 con partidos con números idénticos a los del código actual.
+
+Ejecutable standalone con exit code (asserts):
+    python3 test_process_season_calendar_seed.py
+
+Requiere pandas + numpy + scipy (los usa process_season). NO requiere red ni
+data.json: todo el escenario es sintético.
+"""
+import sys
+
+try:
+    import numpy as np
+    import pandas as pd
+except ImportError:  # pragma: no cover
+    print("FALLO: numpy/pandas no disponibles (requeridos por process_season). "
+          "Instala con: pip install numpy pandas")
+    sys.exit(1)
+
+import update
+
+if update.expit is None:  # pragma: no cover
+    print("FALLO: scipy no disponible (expit requerido por el motor). "
+          "Instala con: pip install scipy")
+    sys.exit(1)
+
+CS = update.CURRENT_SEASON
+
+
+def _teams(n):
+    """Nombres deterministas T00..T{n-1}; no colisionan con NAME_MAP (fix_name
+    es identidad sobre ellos), así el roster esperado es exactamente estos."""
+    return [f'T{i:02d}' for i in range(n)]
+
+
+def _round_robin_calendar(teams):
+    """Doble round-robin: cada par ordenado (h, a) es una jornada con fecha.
+    Cubre a los 20 equipos aunque ninguno haya jugado todavía."""
+    pairs = [(h, a) for h in teams for a in teams if h != a]
+    return [
+        {'gw': i + 1, 'matches': [[h, a]],
+         'dates': [f'2026-08-{(i % 28) + 1:02d}T17:00:00Z']}
+        for i, (h, a) in enumerate(pairs)
+    ]
+
+
+def _two_match_df(teams):
+    """DataFrame de 2 partidos entre 4 de los equipos (formato API con goles)."""
+    h0, a0, h1, a1 = teams[0], teams[1], teams[2], teams[3]
+    return pd.DataFrame({
+        'HomeTeam': [h0, h1],
+        'AwayTeam': [a0, a1],
+        'FTHG':     [2, 1],
+        'FTAG':     [0, 1],
+        'FTR':      ['H', 'D'],
+    })
+
+
+def test_block_seeded_with_all_calendar_teams():
+    """(1) DataFrame de 2 partidos + calendario de 20 → bloque de 20 equipos.
+    Los 16 sin jugar quedan con a/e/m vacíos y gd=0."""
+    teams = _teams(20)
+    cal = _round_robin_calendar(teams)
+    fx = {'ll': {CS: {'calendar': cal}}}
+    wages = {t: 100 - i for i, t in enumerate(teams)}
+    wages['_min'] = min(wages.values())
+    p = update.PARAMS['ll']
+    df = _two_match_df(teams)
+
+    result = update.process_season(df, wages, p['beta'], p['theta1'], p['theta2'], fx, 'll')
+
+    assert set(result.keys()) == set(teams), \
+        f"el bloque debe cubrir los 20 equipos del calendario, got {sorted(result.keys())}"
+    assert len(result) == 20, f"esperados 20 equipos, got {len(result)}"
+
+    played = {teams[0], teams[1], teams[2], teams[3]}
+    for t in teams:
+        if t in played:
+            assert result[t]['a'], f"{t} jugó: `a` no debe estar vacío"
+        else:
+            b = result[t]
+            assert b['a'] == [] and b['e'] == [] and b['m'] == [] and b['gd'] == 0, \
+                f"{t} sin jugar debe tener a/e/m=[] y gd=0, got {b}"
+    print("OK (1) bloque sembrado con los 20 equipos; los 16 sin jugar con estructuras vacías")
+
+
+def test_played_teams_numbers_unchanged_by_seeding():
+    """(2) Los equipos CON partidos conservan números idénticos: el sembrado
+    solo AÑADE equipos vacíos, jamás altera la agregación de los que jugaron.
+
+    El sembrado es inerte para el núcleo numérico (a/e/w/gd y el core de cada
+    entrada de `m`: opp/ih/pts/exp). El baseline es la MISMA `df` corrida por la
+    rama SIN calendario del código actual — que el test (3) verifica byte-idéntica
+    al comportamiento previo por construcción (`calendar_teams` vacío ⇒ universo
+    solo `df`), no un baseline capturado del HEAD anterior. Los índices gw (4) y
+    date (5) de `m` derivan del calendario vía gw_lookup/date_lookup — ya
+    presentes antes de este issue cuando se pasa calendario— y por eso se excluyen
+    de la comparación (en el baseline sin calendario valen 0/'')."""
+    teams = _teams(20)
+    cal = _round_robin_calendar(teams)
+    fx = {'ll': {CS: {'calendar': cal}}}
+    wages = {t: 100 - i for i, t in enumerate(teams)}
+    wages['_min'] = min(wages.values())
+    p = update.PARAMS['ll']
+    df = _two_match_df(teams)
+
+    seeded = update.process_season(df, wages, p['beta'], p['theta1'], p['theta2'], fx, 'll')
+    # Sin calendario: universo solo desde `df` (4 equipos). Reproduce la
+    # agregación del código previo para los equipos con partidos.
+    df_only = update.process_season(df.copy(), wages, p['beta'], p['theta1'], p['theta2'], None, None)
+
+    for t in df_only:
+        assert t in seeded, f"{t} (con partidos) debe seguir en el bloque sembrado"
+        for field in ('a', 'e', 'w', 'gd'):
+            assert seeded[t][field] == df_only[t][field], \
+                (f"{t}.{field} cambió al sembrar el calendario: "
+                 f"seeded={seeded[t][field]!r} df_only={df_only[t][field]!r}")
+        # Core de cada partido (opp/ih/pts/exp) inalterado; gw/date vienen del
+        # calendario (idénticos al código previo con calendario) => se excluyen.
+        assert len(seeded[t]['m']) == len(df_only[t]['m']), \
+            f"{t}: nº de partidos cambió: {len(seeded[t]['m'])} vs {len(df_only[t]['m'])}"
+        for ms, md in zip(seeded[t]['m'], df_only[t]['m']):
+            assert ms[:4] == md[:4], \
+                f"{t}: core del partido cambió al sembrar: {ms[:4]!r} vs {md[:4]!r}"
+    print("OK (2) equipos con partidos: a/e/w/gd y core de `m` idénticos con y sin sembrado")
+
+
+def test_seeded_upgraded_teams_fall_back_to_min_wage():
+    """(spec §3bis.2) Los ascendidos que entran SOLO por calendario, sin salario
+    propio ni de la temporada previa, salen con `w == round(wages['_min'])`, NO
+    con 0. Reproduce el caso real de La Liga 26/27: `all_wages.json` no tiene la
+    clave de la temporada nueva y el relleno desde la previa no cubre a los 3
+    ascendidos (Malaga/La Coruna/Santander).
+
+    Un `w:0` sería falsy y update_cumulative (`not t.get('w')`) descartaría a esos
+    equipos del acumulado histórico incluso tras jugar toda la temporada. Este
+    assert blinda la cadena de fallback y es el que cazaría una regresión del
+    último eslabón (`wages.get('_min', 20)`)."""
+    teams = _teams(20)
+    cal = _round_robin_calendar(teams)
+    fx = {'ll': {CS: {'calendar': cal}}}
+    # Solo 17 equipos con salario propio; los 3 últimos son los "ascendidos"
+    # sin entrada (ni actual ni previa). `_min` disponible como último eslabón.
+    upgraded = set(teams[-3:])
+    wages = {t: 100 - i for i, t in enumerate(teams) if t not in upgraded}
+    wages['_min'] = 20
+    p = update.PARAMS['ll']
+    # df de 2 partidos entre 4 equipos CON salario (no toca a los ascendidos).
+    df = _two_match_df(teams)
+
+    result = update.process_season(df, wages, p['beta'], p['theta1'], p['theta2'], fx, 'll')
+
+    assert set(result.keys()) == set(teams), "el bloque debe cubrir los 20 equipos"
+    for t in upgraded:
+        assert result[t]['w'] == round(wages['_min']), \
+            (f"{t} (ascendido sin salario) debe caer a `_min`="
+             f"{round(wages['_min'])}, got w={result[t]['w']!r} — un 0 falsy lo "
+             f"excluiría de update_cumulative (spec §3bis.2)")
+        assert result[t]['w'] != 0, f"{t}: `w` no debe ser 0 (falsy)"
+    print("OK (salarios) ascendidos sin salario caen a `_min`, no a 0 (spec §3bis.2)")
+
+
+def test_no_calendar_behavior_unchanged():
+    """(3) Sin calendario (o sin lg): `td` solo desde `df` — comportamiento
+    previo intacto, byte-idéntico."""
+    teams = _teams(20)
+    wages = {t: 100 - i for i, t in enumerate(teams)}
+    wages['_min'] = min(wages.values())
+    p = update.PARAMS['ll']
+    df = _two_match_df(teams)
+
+    # Sin fixtures_calendar
+    r1 = update.process_season(df.copy(), wages, p['beta'], p['theta1'], p['theta2'], None, 'll')
+    # Con fixtures_calendar pero sin lg (llamada de liga histórica)
+    fx = {'ll': {CS: {'calendar': _round_robin_calendar(teams)}}}
+    r2 = update.process_season(df.copy(), wages, p['beta'], p['theta1'], p['theta2'], fx, None)
+
+    for r, label in ((r1, 'sin calendario'), (r2, 'sin lg')):
+        assert set(r.keys()) == {teams[0], teams[1], teams[2], teams[3]}, \
+            f"{label}: el universo debe ser solo los 4 equipos de df, got {sorted(r.keys())}"
+    print("OK (3) sin calendario/sin lg: universo solo desde df (comportamiento previo)")
+
+
+def test_full_pipeline_tolerates_zero_played():
+    """(2 del contrato) El resto del pipeline (ranks, remaining, MC) tolera un
+    bloque mixto: 4 equipos con partidos + 16 con 0 jugados. Reproduce el
+    encadenado real de update()."""
+    teams = _teams(20)
+    cal = _round_robin_calendar(teams)
+    fx = {'ll': {CS: {'calendar': cal}}}
+    wages = {t: 100 - i for i, t in enumerate(teams)}
+    wages['_min'] = min(wages.values())
+    p = update.PARAMS['ll']
+    df = _two_match_df(teams)
+
+    result = update.process_season(df, wages, p['beta'], p['theta1'], p['theta2'], fx, 'll')
+
+    # attach_ranks (dentro de process_season) debe dar rank a los 20 (permutación).
+    ranks = [result[t].get('rank') for t in teams]
+    assert sorted(ranks) == list(range(1, 21)), \
+        f"rank debe ser permutación completa 1..20 sobre todo el bloque, got {sorted(ranks)}"
+
+    # remaining + MC no deben romperse con equipos de 0 jugados.
+    remaining = update.get_remaining_fixtures(result, fx, 'll')
+    np.random.seed(0)
+    bands = update.run_mc_simulation(result, wages, p['beta'], p['theta1'], p['theta2'], remaining)
+    assert set(bands.keys()) == set(teams), "las bandas deben cubrir los 20 equipos"
+
+    # Posiciones (camino con partidos: _has_real_block True).
+    cur = update.simulate_current_positions(result, wages, p['beta'], p['theta1'], p['theta2'], remaining, lg='ll')
+    assert set(cur.keys()) == set(teams), "las posiciones deben cubrir los 20 equipos"
+    print("OK (pipeline) ranks 1..20, MC y posiciones toleran los 16 equipos con 0 jugados")
+
+
+if __name__ == '__main__':
+    test_block_seeded_with_all_calendar_teams()
+    test_played_teams_numbers_unchanged_by_seeding()
+    test_seeded_upgraded_teams_fall_back_to_min_wage()
+    test_no_calendar_behavior_unchanged()
+    test_full_pipeline_tolerates_zero_played()
+    print("\nTODOS LOS TESTS OK (process_season siembra calendario, issue #80)")

--- a/update.py
+++ b/update.py
@@ -11,6 +11,7 @@ Usage: python update.py
        FOOTBALL_DATA_API_KEY=xxx python update.py  (to update fixtures from API)
 Requirements: pip install pandas numpy scipy requests
 """
+import copy
 import json, os, sys
 from datetime import datetime
 # Import resiliente por dependencia: permite importar los helpers puros
@@ -1248,14 +1249,26 @@ def compute_all_position_probs(data, fixtures_cal):
             
             # Current season only
             if sn == CURRENT_SEASON:
-                remaining = get_remaining_fixtures(sd, fixtures_cal, lg)
-                cur = simulate_current_positions(sd, wages, p['beta'], p['theta1'], p['theta2'], remaining, lg=lg)
-                pos[lg][sn]['cur'] = cur
-                # Position probability evolution by GW (Phase 2)
-                hist = compute_position_history(sd, wages, p['beta'], p['theta1'], p['theta2'], fixtures_cal, lg, sn, n_sims=2000, gw_step=1)
-                pos[lg][sn]['hist'] = hist
-                if hist:
-                    print(f"      hist: {len(hist)} GW snapshots")
+                if not _has_real_block(sd):
+                    # Pre-season (0 jugados): «actualizada» y «presupuesto» son
+                    # la misma previsión. Dos simulaciones MC independientes
+                    # (pre y cur) divergen por ruido en zonas apiñadas de la
+                    # tabla (issue #76) aunque las entradas sean equivalentes.
+                    # Copiamos `pre` en `cur` (deep copy, sin referencia
+                    # compartida) para que las columnas POS sean idénticas.
+                    # En cuanto haya ≥1 partido jugado, se recae en el camino
+                    # normal con simulate_current_positions.
+                    pos[lg][sn]['cur'] = copy.deepcopy(pre)
+                    pos[lg][sn]['hist'] = []
+                else:
+                    remaining = get_remaining_fixtures(sd, fixtures_cal, lg)
+                    cur = simulate_current_positions(sd, wages, p['beta'], p['theta1'], p['theta2'], remaining, lg=lg)
+                    pos[lg][sn]['cur'] = cur
+                    # Position probability evolution by GW (Phase 2)
+                    hist = compute_position_history(sd, wages, p['beta'], p['theta1'], p['theta2'], fixtures_cal, lg, sn, n_sims=2000, gw_step=1)
+                    pos[lg][sn]['hist'] = hist
+                    if hist:
+                        print(f"      hist: {len(hist)} GW snapshots")
             
             # Log top 3
             top = sorted(pre.items(), key=lambda x: -x[1]['1st'])[:3]

--- a/update.py
+++ b/update.py
@@ -482,6 +482,7 @@ def process_season(filepath_or_df, wages, beta, t1, t2, fixtures_calendar=None, 
     # Build matchday lookup from fixture calendar: (home, away) -> official GW
     gw_lookup = {}
     date_lookup = {}
+    calendar_teams = set()
     if fixtures_calendar and lg:
         cal = fixtures_calendar.get(lg, {}).get(CURRENT_SEASON, {}).get('calendar', [])
         for gw_data in cal:
@@ -490,11 +491,19 @@ def process_season(filepath_or_df, wages, beta, t1, t2, fixtures_calendar=None, 
             for mi, pair in enumerate(gw_data['matches']):
                 h_fix, a_fix = fix_name(pair[0]), fix_name(pair[1])
                 gw_lookup[(h_fix, a_fix)] = gw
+                calendar_teams.add(h_fix)
+                calendar_teams.add(a_fix)
                 if mi < len(dates) and dates[mi]:
                     date_lookup[(h_fix, a_fix)] = dates[mi][:10]
-    
+
+    # Universo de equipos (issue #80): con calendario de CURRENT_SEASON siembra
+    # TODOS sus equipos (vía fix_name en el bucle de arriba) UNIÓN los que
+    # aparezcan en resultados; los que no han jugado quedan con las estructuras
+    # vacías de la inicialización (mismo estado que build_preseason_block). Sin
+    # calendario (ligas históricas, llamadas sin lg) el universo es solo `df` —
+    # byte-idéntico al comportamiento previo.
     td = {}
-    for t in sorted(set(df['HomeTeam']) | set(df['AwayTeam'])):
+    for t in sorted(calendar_teams | set(df['HomeTeam']) | set(df['AwayTeam'])):
         td[t] = {'pts':[],'exp':[],'m':[],'cp':0,'ce':0.0,'gf':0,'ga':0,'gf_away':0,'wins':0,'wins_away':0}
     season_matches = []  # (home, away, home_goals, away_goals) para desempates ADR-005
     for _, r in df.iterrows():
@@ -525,7 +534,12 @@ def process_season(filepath_or_df, wages, beta, t1, t2, fixtures_calendar=None, 
             td[team]['pts'].append(td[team]['cp'])
             td[team]['exp'].append(round(td[team]['ce'], 1))
             td[team]['m'].append([opp, ih, pts, round(exp, 2), official_gw, mdate])
-    result = {t: {'a':d['pts'],'e':d['exp'],'m':d['m'],'w':round(wages.get(t, wages.get(fix_name(t), 0))),'gd':d['gf']-d['ga']} for t,d in td.items()}
+    # Cadena de fallback de salarios (spec §3bis.2): actual -> anterior -> `_min`.
+    # Los ascendidos que entran por calendario (issue #80) sin salario propio ni
+    # de la temporada previa caen al mínimo de liga — mismo eslabón que
+    # build_preseason_block (update.py:1397). Terminar en 0 los emitiría con
+    # `w:0` (falsy), que update_cumulative descartaría en silencio.
+    result = {t: {'a':d['pts'],'e':d['exp'],'m':d['m'],'w':round(wages.get(t, wages.get(fix_name(t), wages.get('_min', 20)))),'gd':d['gf']-d['ga']} for t,d in td.items()}
     stats = {t: {'pts': d['cp'], 'gd': d['gf']-d['ga'], 'gf': d['gf'],
                  'gf_away': d['gf_away'], 'wins': d['wins'], 'wins_away': d['wins_away']}
              for t, d in td.items()}
@@ -1548,7 +1562,11 @@ def update():
         old_gw = len(list(existing.values())[0]['a']) if existing else 0
         data['seasons'][lg][CURRENT_SEASON] = result
         
-        sample = list(result.keys())[0]
+        # Elegir como `sample` de diagnóstico un equipo CON partidos jugados: con
+        # el sembrado del calendario (issue #80) el primero alfabético puede ser
+        # uno de 0 jugados y degradaría este log (GW -> 0), justo el canal que
+        # cazó el «ll: 4 teams» del issue.
+        sample = max(result, key=lambda t: len(result[t]['a']))
         new_gw = len(result[sample]['a'])
         sample_gd = result[sample].get('gd', 'MISSING')
         print(f"  {lg}: {len(result)} teams, GW {old_gw} -> {new_gw}, {sample} gd={sample_gd}")

--- a/update.py
+++ b/update.py
@@ -178,6 +178,11 @@ URLS = {
     'l1': f'{_CSV_BASE}/F1.csv',
     'ed': f'{_CSV_BASE}/N1.csv',
 }
+# Código `Div` esperado por liga, derivado del nombre de fichero en URLS
+# (issue #79): ll→SP1, pl→E0, sa→I1, bl→D1, l1→F1, ed→N1. Es la firma que
+# valida que el CSV descargado es de la liga pedida y no el «más parecido»
+# que football-data.co.uk sirva por fuzzy-redirect.
+EXPECTED_DIV = {lg: url.rsplit('/', 1)[-1].rsplit('.', 1)[0] for lg, url in URLS.items()}
 NAME_MAP = {
     "Nott'm Forest": "Nottm Forest", "Ath Madrid": "At Madrid",
     # Serie A
@@ -369,13 +374,84 @@ def fetch_fixtures_from_api():
 def fix_name(n):
     return NAME_MAP.get(n, n)
 
+def validate_csv_content(text, expected_div, expected_season=None):
+    """Valida que `text` es un CSV de football-data.co.uk de la liga esperada.
+
+    Defensa contra el agujero del issue #79: cuando el CSV de la temporada aún
+    no existe, football-data.co.uk NO devuelve 404 — a veces sirve por
+    fuzzy-redirect el fichero «más parecido» (otra liga), a veces devuelve un
+    cuerpo HTML (status 300). Ninguno debe procesarse como resultados de la
+    liga pedida.
+
+    Contrato:
+      - La primera columna del header debe ser `Div` (tolerando el BOM UTF-8,
+        tanto `\\ufeff` como su representación mojibake `ï»¿`).
+      - El valor de `Div` en la primera fila de datos debe ser `expected_div`.
+      - Si se pasa `expected_season` ('YY/NN'), el año de la primera fecha
+        (`Date`, `dd/mm/yyyy` o `dd/mm/yy`) debe caer en la ventana de esa
+        temporada. Cierra la otra dimensión del mismo fallo de fuzzy-match:
+        servir la temporada PASADA de la liga correcta (mismo `Div`) en la URL
+        de la actual. Solo rechaza cuando el año se parsea limpio y queda
+        fuera de ventana; ausencia/formato raro de `Date` no rechaza (el
+        pipeline ya tolera filas malas con on_bad_lines='skip').
+
+    Devuelve `(ok, motivo)`: `ok` bool; `motivo` describe el rechazo para el
+    log (None si válido). No usa pandas — parseo puro para tests standalone.
+    """
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return False, "fichero vacío"
+    header = lines[0].lstrip('﻿')
+    if header.startswith('ï»¿'):  # BOM mal decodificado (mojibake)
+        header = header[len('ï»¿'):]
+    cols = [c.strip().strip('"') for c in header.split(',')]
+    first_col = cols[0] if cols else ''
+    if first_col != 'Div':
+        return False, f"primera columna {first_col!r} != 'Div' (¿HTML u otra estructura?)"
+    if len(lines) < 2:
+        return False, "sin filas de datos"
+    fields = lines[1].split(',')
+    div_val = fields[0].strip().strip('"')
+    if div_val != expected_div:
+        return False, f"Div={div_val!r} != esperado {expected_div!r}"
+    if expected_season:
+        try:
+            start_year = 2000 + int(expected_season.split('/')[0])
+        except (ValueError, IndexError):
+            start_year = None
+        date_idx = cols.index('Date') if 'Date' in cols else None
+        if start_year is not None and date_idx is not None and date_idx < len(fields):
+            parts = fields[date_idx].strip().strip('"').split('/')
+            if len(parts) == 3 and parts[2].isdigit():
+                yr = int(parts[2])
+                if yr < 100:
+                    yr += 2000
+                if yr not in (start_year, start_year + 1):
+                    return False, (f"año de Date {yr} fuera de la temporada "
+                                   f"{expected_season} ({start_year}/{start_year + 1}) "
+                                   f"— ¿temporada pasada de la misma liga?")
+    return True, None
+
 def download_current_season():
     results = {}
     for lg, url in URLS.items():
         print(f"  Downloading {lg}...")
         try:
-            r = requests.get(url, timeout=30)
-            r.raise_for_status()
+            # allow_redirects=False: un 3xx (fuzzy-redirect a otra liga) NO se
+            # sigue; cualquier status != 200 es fallo (issue #79).
+            r = requests.get(url, timeout=30, allow_redirects=False)
+            if r.status_code != 200:
+                print(f"    FAILED: status {r.status_code} (url {url}) — "
+                      f"redirect/HTML rechazado")
+                results[lg] = None
+                continue
+            expected_div = EXPECTED_DIV[lg]
+            ok, reason = validate_csv_content(r.text, expected_div, CURRENT_SEASON)
+            if not ok:
+                print(f"    WARNING: contenido inválido para {lg} "
+                      f"(esperaba Div={expected_div}): {reason} — descartado")
+                results[lg] = None
+                continue
             path = os.path.join(DATA_DIR, f'current_{lg}.csv')
             with open(path, 'w') as f:
                 f.write(r.text)


### PR DESCRIPTION
Promoción develop→main autorizada por el propietario en chat. Contiene PRs #81 y #83 (+ #77 ya validado). Validación pre-promote ejecutada localmente contra data.json de producción: run completo sin crash, bloque ll regenerado con 20 equipos en test directo.